### PR TITLE
Server: Avoid `Arc::clone()` on the configuration.

### DIFF
--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -20,6 +20,6 @@ fuzz_target!(|data: &[u8]| {
                           .unwrap()
                           .with_no_client_auth()
                           .with_cert_resolver(Arc::new(Fail)));
-    let mut server= ServerConnection::new(&config);
+    let mut server = ServerConnection::new(config);
     let _ = server.read_tls(&mut io::Cursor::new(data));
 });

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -71,7 +71,7 @@ impl TlsServer {
                 Ok((socket, addr)) => {
                     debug!("Accepting new connection from {:?}", addr);
 
-                    let tls_conn = rustls::ServerConnection::new(&self.tls_config);
+                    let tls_conn = rustls::ServerConnection::new(Arc::clone(&self.tls_config));
                     let mode = self.mode.clone();
 
                     let token = mio::Token(self.next_id);

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -372,7 +372,7 @@ fn bench_handshake(params: &BenchmarkParam, clientauth: ClientAuth, resume: Resu
     for _ in 0..rounds {
         let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
         let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
-        let mut server = ServerConnection::new(&server_config);
+        let mut server = ServerConnection::new(Arc::clone(&server_config));
 
         server_time += time(|| {
             transfer(&mut client, &mut server);
@@ -447,7 +447,7 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, mtu: Option<usize>) 
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
     let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
-    let mut server = ServerConnection::new(&server_config);
+    let mut server = ServerConnection::new(Arc::clone(&server_config));
 
     do_handshake(&mut client, &mut server);
 
@@ -515,7 +515,7 @@ fn bench_memory(params: &BenchmarkParam, conn_count: u64) {
     let mut clients = Vec::with_capacity(conn_count);
 
     for _i in 0..conn_count {
-        servers.push(ServerConnection::new(&server_config));
+        servers.push(ServerConnection::new(Arc::clone(&server_config)));
         let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
         clients.push(ClientConnection::new(&client_config, dns_name).unwrap());
     }

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -1089,11 +1089,12 @@ fn main() {
         ccfg: &Option<Arc<rustls::ClientConfig>>,
     ) -> ClientOrServer {
         if opts.server {
+            let scfg = Arc::clone(scfg.as_ref().unwrap());
             let s = if opts.quic_transport_params.is_empty() {
-                rustls::ServerConnection::new(scfg.as_ref().unwrap())
+                rustls::ServerConnection::new(scfg)
             } else {
                 rustls::ServerConnection::new_quic(
-                    scfg.as_ref().unwrap(),
+                    scfg,
                     quic::Version::V1,
                     opts.quic_transport_params.clone(),
                 )

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -227,17 +227,14 @@ pub struct ServerConnection {
 impl ServerConnection {
     /// Make a new ServerConnection.  `config` controls how
     /// we behave in the TLS protocol.
-    pub fn new(config: &Arc<ServerConfig>) -> ServerConnection {
+    pub fn new(config: Arc<ServerConfig>) -> ServerConnection {
         Self::from_config(config, vec![])
     }
 
-    fn from_config(config: &Arc<ServerConfig>, extra_exts: Vec<ServerExtension>) -> Self {
+    fn from_config(config: Arc<ServerConfig>, extra_exts: Vec<ServerExtension>) -> Self {
         ServerConnection {
             common: ConnectionCommon::new(config.mtu, false),
-            state: Some(Box::new(hs::ExpectClientHello::new(
-                config.clone(),
-                extra_exts,
-            ))),
+            state: Some(Box::new(hs::ExpectClientHello::new(config, extra_exts))),
             data: ServerConnectionData::default(),
         }
     }
@@ -477,7 +474,7 @@ pub trait ServerQuicExt {
     /// in that it takes an extra argument, `params`, which contains the
     /// TLS-encoded transport parameters to send.
     fn new_quic(
-        config: &Arc<ServerConfig>,
+        config: Arc<ServerConfig>,
         quic_version: quic::Version,
         params: Vec<u8>,
     ) -> Result<ServerConnection, Error> {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -529,7 +529,7 @@ fn server_cert_resolve_with_sni() {
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("the-value-from-sni"))
                 .unwrap();
-        let mut server = ServerConnection::new(&Arc::new(server_config));
+        let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert_eq!(err.is_err(), true);
@@ -550,7 +550,7 @@ fn server_cert_resolve_with_alpn() {
 
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("sni-value")).unwrap();
-        let mut server = ServerConnection::new(&Arc::new(server_config));
+        let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert_eq!(err.is_err(), true);
@@ -570,7 +570,7 @@ fn client_trims_terminating_dot() {
 
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("some-host.com.")).unwrap();
-        let mut server = ServerConnection::new(&Arc::new(server_config));
+        let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert_eq!(err.is_err(), true);
@@ -594,7 +594,7 @@ fn check_sigalgs_reduced_by_ciphersuite(
 
     let mut client =
         ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
-    let mut server = ServerConnection::new(&Arc::new(server_config));
+    let mut server = ServerConnection::new(Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
     assert_eq!(err.is_err(), true);
@@ -653,7 +653,7 @@ fn client_with_sni_disabled_does_not_send_sni() {
             let mut client =
                 ClientConnection::new(&Arc::new(client_config), dns_name("value-not-sent"))
                     .unwrap();
-            let mut server = ServerConnection::new(&server_config);
+            let mut server = ServerConnection::new(Arc::clone(&server_config));
 
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(err.is_err(), true);
@@ -673,7 +673,7 @@ fn client_checks_server_certificate_with_given_name() {
                 dns_name("not-the-right-hostname.com"),
             )
             .unwrap();
-            let mut server = ServerConnection::new(&server_config);
+            let mut server = ServerConnection::new(Arc::clone(&server_config));
 
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(
@@ -872,7 +872,7 @@ mod test_clientverifier {
             let client_config = make_client_config_with_auth(*kt);
 
             for client_config in AllClientVersions::new(client_config) {
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("notlocalhost"))
                         .unwrap();
@@ -906,7 +906,7 @@ mod test_clientverifier {
             let client_config = make_client_config(*kt);
 
             for client_config in AllClientVersions::new(client_config) {
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("notlocalhost"))
                         .unwrap();
@@ -941,7 +941,7 @@ mod test_clientverifier {
 
             for client_config in AllClientVersions::new(client_config) {
                 println!("Failing: {:?}", client_config.versions);
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
@@ -974,7 +974,7 @@ mod test_clientverifier {
             let client_config = make_client_config_with_auth(*kt);
 
             for client_config in AllClientVersions::new(client_config) {
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
                 let err = do_handshake_until_error(&mut client, &mut server);
@@ -1002,7 +1002,7 @@ mod test_clientverifier {
             let client_config = make_client_config_with_auth(*kt);
 
             for client_config in AllClientVersions::new(client_config) {
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
@@ -1964,7 +1964,7 @@ fn server_exposes_offered_sni() {
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("second.testserver.com"))
                 .unwrap();
-        let mut server = ServerConnection::new(&Arc::new(make_server_config(kt)));
+        let mut server = ServerConnection::new(Arc::new(make_server_config(kt)));
 
         assert_eq!(None, server.sni_hostname());
         do_handshake(&mut client, &mut server);
@@ -1980,7 +1980,7 @@ fn server_exposes_offered_sni_smashed_to_lowercase() {
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("SECOND.TESTServer.com"))
                 .unwrap();
-        let mut server = ServerConnection::new(&Arc::new(make_server_config(kt)));
+        let mut server = ServerConnection::new(Arc::new(make_server_config(kt)));
 
         assert_eq!(None, server.sni_hostname());
         do_handshake(&mut client, &mut server);
@@ -1998,7 +1998,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
     let server_config = Arc::new(server_config);
 
     for client_config in AllClientVersions::new(make_client_config(kt)) {
-        let mut server = ServerConnection::new(&server_config);
+        let mut server = ServerConnection::new(Arc::clone(&server_config));
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("thisdoesNOTexist.com"))
                 .unwrap();
@@ -2032,13 +2032,13 @@ fn sni_resolver_works() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    let mut server1 = ServerConnection::new(&server_config);
+    let mut server1 = ServerConnection::new(Arc::clone(&server_config));
     let mut client1 =
         ClientConnection::new(&Arc::new(make_client_config(kt)), dns_name("localhost")).unwrap();
     let err = do_handshake_until_error(&mut client1, &mut server1);
     assert_eq!(err, Ok(()));
 
-    let mut server2 = ServerConnection::new(&server_config);
+    let mut server2 = ServerConnection::new(Arc::clone(&server_config));
     let mut client2 =
         ClientConnection::new(&Arc::new(make_client_config(kt)), dns_name("notlocalhost")).unwrap();
     let err = do_handshake_until_error(&mut client2, &mut server2);
@@ -2989,9 +2989,12 @@ mod test_quic {
         )
         .unwrap();
 
-        let mut server =
-            ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
-                .unwrap();
+        let mut server = ServerConnection::new_quic(
+            Arc::clone(&server_config),
+            quic::Version::V1,
+            server_params.into(),
+        )
+        .unwrap();
 
         let client_initial = step(&mut client, &mut server).unwrap();
         assert!(client_initial.is_none());
@@ -3043,9 +3046,12 @@ mod test_quic {
                 .is_some()
         );
 
-        let mut server =
-            ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
-                .unwrap();
+        let mut server = ServerConnection::new_quic(
+            Arc::clone(&server_config),
+            quic::Version::V1,
+            server_params.into(),
+        )
+        .unwrap();
 
         step(&mut client, &mut server).unwrap();
         assert_eq!(client.quic_transport_parameters(), Some(server_params));
@@ -3077,9 +3083,12 @@ mod test_quic {
             )
             .unwrap();
 
-            let mut server =
-                ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
-                    .unwrap();
+            let mut server = ServerConnection::new_quic(
+                Arc::clone(&server_config),
+                quic::Version::V1,
+                server_params.into(),
+            )
+            .unwrap();
 
             step(&mut client, &mut server).unwrap();
             assert_eq!(client.quic_transport_parameters(), Some(server_params));
@@ -3107,7 +3116,7 @@ mod test_quic {
         .unwrap();
 
         let mut server =
-            ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
+            ServerConnection::new_quic(server_config, quic::Version::V1, server_params.into())
                 .unwrap();
 
         step(&mut client, &mut server).unwrap();
@@ -3149,7 +3158,7 @@ mod test_quic {
             )
             .unwrap();
             let mut server =
-                ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
+                ServerConnection::new_quic(server_config, quic::Version::V1, server_params.into())
                     .unwrap();
 
             assert_eq!(
@@ -3194,7 +3203,7 @@ mod test_quic {
 
         assert!(
             ServerConnection::new_quic(
-                &server_config,
+                server_config,
                 quic::Version::V1,
                 b"server params".to_vec(),
             )
@@ -3225,7 +3234,7 @@ mod test_quic {
 
             let wrapped = Arc::new(server_config.clone());
             assert_eq!(
-                ServerConnection::new_quic(&wrapped, quic::Version::V1, b"server params".to_vec(),)
+                ServerConnection::new_quic(wrapped, quic::Version::V1, b"server params".to_vec(),)
                     .is_ok(),
                 ok
             );
@@ -3241,12 +3250,9 @@ mod test_quic {
         server_config.alpn_protocols = vec!["foo".into()];
         let server_config = Arc::new(server_config);
 
-        let mut server = ServerConnection::new_quic(
-            &server_config,
-            quic::Version::V1,
-            b"server params".to_vec(),
-        )
-        .unwrap();
+        let mut server =
+            ServerConnection::new_quic(server_config, quic::Version::V1, b"server params".to_vec())
+                .unwrap();
 
         use ring::rand::SecureRandom;
         use rustls::internal::msgs::base::PayloadU16;
@@ -3332,12 +3338,9 @@ mod test_quic {
             .compute_public_key()
             .unwrap();
 
-        let mut server = ServerConnection::new_quic(
-            &server_config,
-            quic::Version::V1,
-            b"server params".to_vec(),
-        )
-        .unwrap();
+        let mut server =
+            ServerConnection::new_quic(server_config, quic::Version::V1, b"server params".to_vec())
+                .unwrap();
 
         let client_hello = Message {
             version: ProtocolVersion::TLSv1_2,

--- a/rustls/tests/benchmarks.rs
+++ b/rustls/tests/benchmarks.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 fn bench_ewouldblock(c: &mut Criterion) {
     let server_config = make_server_config(KeyType::RSA);
-    let mut server = ServerConnection::new(&Arc::new(server_config));
+    let mut server = ServerConnection::new(Arc::new(server_config));
     let mut read_ewouldblock = FailsReads::new(io::ErrorKind::WouldBlock);
     c.bench_function("read_tls with EWOULDBLOCK", move |b| {
         b.iter(|| server.read_tls(&mut read_ewouldblock))

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -293,8 +293,8 @@ pub fn make_pair_for_arc_configs(
     server_config: &Arc<ServerConfig>,
 ) -> (ClientConnection, ServerConnection) {
     (
-        ClientConnection::new(client_config, dns_name("localhost")).unwrap(),
-        ServerConnection::new(server_config),
+        ClientConnection::new(&client_config, dns_name("localhost")).unwrap(),
+        ServerConnection::new(Arc::clone(server_config)),
     )
 }
 


### PR DESCRIPTION
Avoid introducing any memory barrier through the cloning of the configuration
by avoiding the cloning.

Especially if the user doesn't need to use the config more more than one
connection, the internal clone is wasteful.