### PR TITLE
Client: Avoid `Arc::clone()` on the configuration.

### DIFF
--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -15,6 +15,6 @@ fuzz_target!(|data: &[u8]| {
         .with_root_certificates(root_store, &[])
         .with_no_client_auth());
     let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
-    let mut client = ClientConnection::new(&config, example_com).unwrap();
+    let mut client = ClientConnection::new(config, example_com).unwrap();
     let _ = client.read_tls(&mut io::Cursor::new(data));
 });

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -45,7 +45,7 @@ impl TlsClient {
             socket: sock,
             closing: false,
             clean_closure: false,
-            tls_conn: rustls::ClientConnection::new(&cfg, hostname).unwrap(),
+            tls_conn: rustls::ClientConnection::new(cfg, hostname).unwrap(),
         }
     }
 

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -371,7 +371,7 @@ fn bench_handshake(params: &BenchmarkParam, clientauth: ClientAuth, resume: Resu
 
     for _ in 0..rounds {
         let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-        let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
+        let mut client = ClientConnection::new(Arc::clone(&client_config), dns_name).unwrap();
         let mut server = ServerConnection::new(Arc::clone(&server_config));
 
         server_time += time(|| {
@@ -446,7 +446,7 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, mtu: Option<usize>) 
     ));
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-    let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
+    let mut client = ClientConnection::new(client_config, dns_name).unwrap();
     let mut server = ServerConnection::new(Arc::clone(&server_config));
 
     do_handshake(&mut client, &mut server);
@@ -517,7 +517,7 @@ fn bench_memory(params: &BenchmarkParam, conn_count: u64) {
     for _i in 0..conn_count {
         servers.push(ServerConnection::new(Arc::clone(&server_config)));
         let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-        clients.push(ClientConnection::new(&client_config, dns_name).unwrap());
+        clients.push(ClientConnection::new(Arc::clone(&client_config), dns_name).unwrap());
     }
 
     for _step in 0..5 {

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -1103,11 +1103,12 @@ fn main() {
             ClientOrServer::Server(s)
         } else {
             let dns_name = webpki::DnsNameRef::try_from_ascii_str(&opts.host_name).unwrap();
+            let ccfg = Arc::clone(ccfg.as_ref().unwrap());
             let c = if opts.quic_transport_params.is_empty() {
-                rustls::ClientConnection::new(ccfg.as_ref().unwrap(), dns_name)
+                rustls::ClientConnection::new(ccfg, dns_name)
             } else {
                 rustls::ClientConnection::new_quic(
-                    ccfg.as_ref().unwrap(),
+                    ccfg,
                     quic::Version::V1,
                     dns_name,
                     opts.quic_transport_params.clone(),

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -53,7 +53,7 @@ fn communicate(
 ) -> Result<Verdict, Box<dyn StdError>> {
     let dns_name = webpki::DnsNameRef::try_from_ascii_str(&host).unwrap();
     let rc_config = Arc::new(config);
-    let mut client = ClientConnection::new(&rc_config, dns_name).unwrap();
+    let mut client = ClientConnection::new(rc_config, dns_name).unwrap();
     let mut stream = TcpStream::connect((&*host, port))?;
 
     client

--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -26,7 +26,7 @@ fn main() {
     .with_no_client_auth();
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
-    let mut conn = rustls::ClientConnection::new(&Arc::new(config), dns_name).unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), dns_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write(

--- a/rustls/examples/simple_0rtt_client.rs
+++ b/rustls/examples/simple_0rtt_client.rs
@@ -11,7 +11,7 @@ use webpki_roots;
 
 fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
     let dns_name = webpki::DnsNameRef::try_from_ascii_str(domain_name).unwrap();
-    let mut conn = rustls::ClientConnection::new(config, dns_name).unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::clone(&config), dns_name).unwrap();
     let mut sock = TcpStream::connect(format!("{}:443", domain_name)).unwrap();
     sock.set_nodelay(true).unwrap();
     let request = format!(

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -28,7 +28,7 @@ fn main() {
         .with_no_client_auth();
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
-    let mut conn = rustls::ClientConnection::new(&Arc::new(config), dns_name).unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), dns_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write(

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -113,7 +113,7 @@ fn find_session(
 pub(super) fn start_handshake(
     dns_name: webpki::DnsName,
     extra_exts: Vec<ClientExtension>,
-    config: &Arc<ClientConfig>,
+    config: Arc<ClientConfig>,
     cx: &mut ClientContext<'_>,
 ) -> NextStateOrError {
     let mut transcript = HandshakeHash::new();
@@ -129,13 +129,13 @@ pub(super) fn start_handshake(
     let mut session_id: Option<SessionID> = None;
     let mut resuming_session = find_session(
         dns_name.as_ref(),
-        config,
+        &config,
         #[cfg(feature = "quic")]
         cx,
     );
 
     let key_share = if support_tls13 {
-        Some(tls13::initial_key_share(config, dns_name.as_ref())?)
+        Some(tls13::initial_key_share(&config, dns_name.as_ref())?)
     } else {
         None
     };
@@ -167,7 +167,7 @@ pub(super) fn start_handshake(
     let sent_tls13_fake_ccs = false;
     let may_send_sct_list = config.verifier.request_scts();
     Ok(emit_client_hello_for_retry(
-        config.clone(),
+        config,
         cx,
         resuming_session,
         randoms,

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -333,14 +333,14 @@ impl ClientConnection {
     /// we behave in the TLS protocol, `hostname` is the
     /// hostname of who we want to talk to.
     pub fn new(
-        config: &Arc<ClientConfig>,
+        config: Arc<ClientConfig>,
         hostname: webpki::DnsNameRef,
     ) -> Result<ClientConnection, Error> {
         Self::new_inner(config, hostname, Vec::new(), Protocol::Tcp)
     }
 
     fn new_inner(
-        config: &Arc<ClientConfig>,
+        config: Arc<ClientConfig>,
         hostname: webpki::DnsNameRef,
         extra_exts: Vec<ClientExtension>,
         proto: Protocol,
@@ -583,7 +583,7 @@ pub trait ClientQuicExt {
     /// in that it takes an extra argument, `params`, which contains the
     /// TLS-encoded transport parameters to send.
     fn new_quic(
-        config: &Arc<ClientConfig>,
+        config: Arc<ClientConfig>,
         quic_version: quic::Version,
         hostname: webpki::DnsNameRef,
         params: Vec<u8>,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -130,7 +130,7 @@
 //! #     .with_no_client_auth();
 //! let rc_config = Arc::new(config);
 //! let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
-//! let mut client = rustls::ClientConnection::new(&rc_config, example_com);
+//! let mut client = rustls::ClientConnection::new(rc_config, example_com);
 //! ```
 //!
 //! Now you should do appropriate IO for the `client` object.  If `client.wants_read()` yields

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -527,8 +527,7 @@ fn server_cert_resolve_with_sni() {
         });
 
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("the-value-from-sni"))
-                .unwrap();
+            ClientConnection::new(Arc::new(client_config), dns_name("the-value-from-sni")).unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
@@ -549,7 +548,7 @@ fn server_cert_resolve_with_alpn() {
         });
 
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("sni-value")).unwrap();
+            ClientConnection::new(Arc::new(client_config), dns_name("sni-value")).unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
@@ -569,7 +568,7 @@ fn client_trims_terminating_dot() {
         });
 
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("some-host.com.")).unwrap();
+            ClientConnection::new(Arc::new(client_config), dns_name("some-host.com.")).unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
@@ -592,8 +591,7 @@ fn check_sigalgs_reduced_by_ciphersuite(
         ..Default::default()
     });
 
-    let mut client =
-        ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+    let mut client = ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
     let mut server = ServerConnection::new(Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
@@ -651,8 +649,7 @@ fn client_with_sni_disabled_does_not_send_sni() {
 
         for client_config in AllClientVersions::new(client_config) {
             let mut client =
-                ClientConnection::new(&Arc::new(client_config), dns_name("value-not-sent"))
-                    .unwrap();
+                ClientConnection::new(Arc::new(client_config), dns_name("value-not-sent")).unwrap();
             let mut server = ServerConnection::new(Arc::clone(&server_config));
 
             let err = do_handshake_until_error(&mut client, &mut server);
@@ -669,7 +666,7 @@ fn client_checks_server_certificate_with_given_name() {
 
         for client_config in AllClientVersions::new(client_config) {
             let mut client = ClientConnection::new(
-                &Arc::new(client_config),
+                Arc::new(client_config),
                 dns_name("not-the-right-hostname.com"),
             )
             .unwrap();
@@ -874,7 +871,7 @@ mod test_clientverifier {
             for client_config in AllClientVersions::new(client_config) {
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("notlocalhost"))
+                    ClientConnection::new(Arc::new(client_config), dns_name("notlocalhost"))
                         .unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
                 assert_eq!(
@@ -908,7 +905,7 @@ mod test_clientverifier {
             for client_config in AllClientVersions::new(client_config) {
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("notlocalhost"))
+                    ClientConnection::new(Arc::new(client_config), dns_name("notlocalhost"))
                         .unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
                 assert_eq!(
@@ -943,7 +940,7 @@ mod test_clientverifier {
                 println!("Failing: {:?}", client_config.versions);
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+                    ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
                 assert_eq!(
                     errs,
@@ -976,7 +973,7 @@ mod test_clientverifier {
             for client_config in AllClientVersions::new(client_config) {
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+                    ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
                 let err = do_handshake_until_error(&mut client, &mut server);
                 assert_eq!(
                     err,
@@ -1004,7 +1001,7 @@ mod test_clientverifier {
             for client_config in AllClientVersions::new(client_config) {
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+                    ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
                 assert_eq!(
                     errs,
@@ -1962,7 +1959,7 @@ fn server_exposes_offered_sni() {
     let kt = KeyType::RSA;
     for client_config in AllClientVersions::new(make_client_config(kt)) {
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("second.testserver.com"))
+            ClientConnection::new(Arc::new(client_config), dns_name("second.testserver.com"))
                 .unwrap();
         let mut server = ServerConnection::new(Arc::new(make_server_config(kt)));
 
@@ -1978,7 +1975,7 @@ fn server_exposes_offered_sni_smashed_to_lowercase() {
     let kt = KeyType::RSA;
     for client_config in AllClientVersions::new(make_client_config(kt)) {
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("SECOND.TESTServer.com"))
+            ClientConnection::new(Arc::new(client_config), dns_name("SECOND.TESTServer.com"))
                 .unwrap();
         let mut server = ServerConnection::new(Arc::new(make_server_config(kt)));
 
@@ -2000,7 +1997,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
     for client_config in AllClientVersions::new(make_client_config(kt)) {
         let mut server = ServerConnection::new(Arc::clone(&server_config));
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("thisdoesNOTexist.com"))
+            ClientConnection::new(Arc::new(client_config), dns_name("thisdoesNOTexist.com"))
                 .unwrap();
 
         assert_eq!(None, server.sni_hostname());
@@ -2034,13 +2031,13 @@ fn sni_resolver_works() {
 
     let mut server1 = ServerConnection::new(Arc::clone(&server_config));
     let mut client1 =
-        ClientConnection::new(&Arc::new(make_client_config(kt)), dns_name("localhost")).unwrap();
+        ClientConnection::new(Arc::new(make_client_config(kt)), dns_name("localhost")).unwrap();
     let err = do_handshake_until_error(&mut client1, &mut server1);
     assert_eq!(err, Ok(()));
 
     let mut server2 = ServerConnection::new(Arc::clone(&server_config));
     let mut client2 =
-        ClientConnection::new(&Arc::new(make_client_config(kt)), dns_name("notlocalhost")).unwrap();
+        ClientConnection::new(Arc::new(make_client_config(kt)), dns_name("notlocalhost")).unwrap();
     let err = do_handshake_until_error(&mut client2, &mut server2);
     assert_eq!(
         err,
@@ -2982,7 +2979,7 @@ mod test_quic {
 
         // full handshake
         let mut client = ClientConnection::new_quic(
-            &client_config,
+            Arc::clone(&client_config),
             quic::Version::V1,
             dns_name("localhost"),
             client_params.into(),
@@ -3034,7 +3031,7 @@ mod test_quic {
 
         // 0-RTT handshake
         let mut client = ClientConnection::new_quic(
-            &client_config,
+            Arc::clone(&client_config),
             quic::Version::V1,
             dns_name("localhost"),
             client_params.into(),
@@ -3076,7 +3073,7 @@ mod test_quic {
             let mut client_config = (*client_config).clone();
             client_config.alpn_protocols = vec!["foo".into()];
             let mut client = ClientConnection::new_quic(
-                &Arc::new(client_config),
+                Arc::new(client_config),
                 quic::Version::V1,
                 dns_name("localhost"),
                 client_params.into(),
@@ -3108,7 +3105,7 @@ mod test_quic {
 
         // failed handshake
         let mut client = ClientConnection::new_quic(
-            &client_config,
+            client_config,
             quic::Version::V1,
             dns_name("example.com"),
             client_params.into(),
@@ -3151,7 +3148,7 @@ mod test_quic {
             let server_config = Arc::new(server_config);
 
             let mut client = ClientConnection::new_quic(
-                &client_config,
+                client_config,
                 quic::Version::V1,
                 dns_name("localhost"),
                 client_params.into(),
@@ -3186,7 +3183,7 @@ mod test_quic {
 
         assert!(
             ClientConnection::new_quic(
-                &client_config,
+                client_config,
                 quic::Version::V1,
                 dns_name("localhost"),
                 b"client params".to_vec(),
@@ -3582,7 +3579,7 @@ fn test_client_mtu_reduction() {
         client_config.set_mtu(&Some(64));
 
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+            ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
         let writes = collect_write_lengths(&mut client);
         println!("writes at mtu=64: {:?}", writes);
         assert!(writes.iter().all(|x| *x <= 64));

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -293,7 +293,7 @@ pub fn make_pair_for_arc_configs(
     server_config: &Arc<ServerConfig>,
 ) -> (ClientConnection, ServerConnection) {
     (
-        ClientConnection::new(&client_config, dns_name("localhost")).unwrap(),
+        ClientConnection::new(Arc::clone(&client_config), dns_name("localhost")).unwrap(),
         ServerConnection::new(Arc::clone(server_config)),
     )
 }


### PR DESCRIPTION
Avoid introducing any memory barrier through the cloning of the configuration
by avoiding the cloning.

Especially if the user doesn't need to use the config more more than one
connection, the internal clone is wasteful.